### PR TITLE
allow spawn runners with the same role as parent

### DIFF
--- a/runner-from-userdata.tf
+++ b/runner-from-userdata.tf
@@ -59,8 +59,8 @@ data "template_file" "gitlab_runner" {
     runners_use_private_address = "${var.runners_use_private_address}"
     bucket_name                 = "${aws_s3_bucket.build_cache.bucket}"
     runner_environment_tag      = "${var.environment}"
-
-    runners_config = "${data.template_file.runners.rendered}"
+    instance-profile-name       = "${aws_iam_instance_profile.instance.name}"
+    runners_config              = "${data.template_file.runners.rendered}"
   }
 }
 

--- a/template/gitlab-runner.tpl
+++ b/template/gitlab-runner.tpl
@@ -43,6 +43,7 @@ gitlab-runner register \
   --machine-machine-options "amazonec2-request-spot-instance=true" \
   --machine-machine-options "amazonec2-spot-price=${runners_spot_price_bid}" \
   --machine-machine-options "amazonec2-security-group=${runners_security_group_name}" \
+  --machine-machine-options "amazonec2-iam-instance-profile=${instance-profile-name}" \
   --machine-machine-options "amazonec2-tags=environment,${environment}" \
   --machine-machine-options "amazonec2-monitoring=${runners_monitoring}" \
   --machine-machine-options "amazonec2-root-size=${runners_root_size}" \


### PR DESCRIPTION
Please consider this changes to allow spawn spot instances with the same iam role.
This role is in module output so it will allow users to assign additional permissions for executors (for instance access to lambda funcs)
