### PR TITLE
Feature/docker host distinct role

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,8 +125,8 @@ All variables and defaults:
 ## Outputs
 Name  	      				| Description
 ----------------------------------------|--------------------------------------------
-gitlab_runner_role  			| gitlab runner role
-gitlab_runner_workers_role  		| role that will be assigned to workers
+gitlab_runner_role_name  		| role name that will be assigned to gitlab runner
+gitlab_runner_workers_role_name  	| role name that will be assigned to workers
 gitlab_runner_security_group_id 	| security group id attached to gitlab runner
 gitlab_docker_machine_security_group_id | security group id attached to workers
 

--- a/README.md
+++ b/README.md
@@ -123,10 +123,12 @@ All variables and defaults:
 | use_prebacked_ami             | Use prebacked ami for runner by default                                                                             | string |        0         |   yes    |
 
 ## Outputs
-* gitlab_runner_role - gitlab runner role
-* gitlab_runner_workers_role - role that will be assigned to workers 
-* gitlab_runner_security_group_id - security group id attached to gitlab runner
-* gitlab_docker_machine_security_group_id  security group id attached to workers
+Name  	      				| Description
+----------------------------------------|--------------------------------------------
+gitlab_runner_role  			| gitlab runner role
+gitlab_runner_workers_role  		| role that will be assigned to workers
+gitlab_runner_security_group_id 	| security group id attached to gitlab runner
+gitlab_docker_machine_security_group_id | security group id attached to workers
 
 ## Tests
 

--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ All variables and defaults:
 ## Outputs
 Name  	      				| Description
 ----------------------------------------|--------------------------------------------
-gitlab_runner_role_name  		| role name that will be assigned to gitlab runner
+gitlab_runner_role  			| role name that will be assigned to gitlab runner
 gitlab_runner_workers_role_name  	| role name that will be assigned to workers
 gitlab_runner_security_group_id 	| security group id attached to gitlab runner
 gitlab_docker_machine_security_group_id | security group id attached to workers

--- a/README.md
+++ b/README.md
@@ -33,6 +33,28 @@ resource "aws_iam_service_linked_role" "autoscaling" {
 }
 ```
 
+### Workers linked role
+Empty role will be created. 
+```hcl
+resource "aws_iam_role" "runner" {
+  name = "${var.environment}-runner-role"
+
+  #The policy that grants an entity permission to assume the role
+  assume_role_policy = "${data.template_file.instance_role_trust_policy.rendered}"
+}
+
+resource "aws_iam_instance_profile" "runner" {
+  name = "${var.environment}-runner-profile"
+  role = "${aws_iam_role.runner.name}"
+}
+```
+
+This role will be passed as an argument to
+docker-machine aws cloud provider driver (--amazonec2-iam-instance-profile please refer to [docker-machine aws driver docs](https://docs.docker.com/machine/drivers/aws/) 
+for more detailed info) and docker hosts will be spawned with it. You can refer to this role via
+module output and  attach all required policies for your workflow 
+
+
 ## Usage
 
 ### Conditional creation
@@ -101,6 +123,10 @@ All variables and defaults:
 | use_prebacked_ami             | Use prebacked ami for runner by default                                                                             | string |        0         |   yes    |
 
 ## Outputs
+* gitlab_runner_role - gitlab runner role
+* gitlab_runner_workers_role - role that will be assigned to workers 
+* gitlab_runner_security_group_id - security group id attached to gitlab runner
+* gitlab_docker_machine_security_group_id  security group id attached to workers
 
 ## Tests
 

--- a/main.tf
+++ b/main.tf
@@ -34,16 +34,6 @@ resource "aws_security_group" "runner" {
   tags = "${local.tags}"
 }
 
-resource "aws_security_group_rule" "ssh_from_cidr_blocks" {
-  count             = "${length(var.allow_ssh_cidr_blocks) != 0 ? 1 : 0}"
-  type              = "ingress"
-  from_port         = 22
-  to_port           = 22
-  protocol          = "tcp"
-  cidr_blocks       = ["${var.allow_ssh_cidr_blocks}"]
-  security_group_id = "${aws_security_group.runner.id}"
-}
-
 resource "aws_security_group" "docker_machine" {
   name_prefix = "${var.environment}-docker-machine"
   vpc_id      = "${var.vpc_id}"

--- a/main.tf
+++ b/main.tf
@@ -34,6 +34,16 @@ resource "aws_security_group" "runner" {
   tags = "${local.tags}"
 }
 
+resource "aws_security_group_rule" "ssh_from_cidr_blocks" {
+  count             = "${length(var.allow_ssh_cidr_blocks) != 0 ? 1 : 0}"
+  type              = "ingress"
+  from_port         = 22
+  to_port           = 22
+  protocol          = "tcp"
+  cidr_blocks       = ["${var.allow_ssh_cidr_blocks}"]
+  security_group_id = "${aws_security_group.runner.id}"
+}
+
 resource "aws_security_group" "docker_machine" {
   name_prefix = "${var.environment}-docker-machine"
   vpc_id      = "${var.vpc_id}"
@@ -60,6 +70,21 @@ resource "aws_security_group" "docker_machine" {
   }
 
   tags = "${local.tags}"
+}
+
+################################################################################
+### Runner blank role
+################################################################################
+resource "aws_iam_role" "runner" {
+  name = "${var.environment}-runner-role"
+
+  #The policy that grants an entity permission to assume the role
+  assume_role_policy = "${data.template_file.instance_role_trust_policy.rendered}"
+}
+
+resource "aws_iam_instance_profile" "runner" {
+  name = "${var.environment}-runner-profile"
+  role = "${aws_iam_role.runner.name}"
 }
 
 ################################################################################

--- a/outputs.tf
+++ b/outputs.tf
@@ -3,6 +3,11 @@ output "gitlab_runner_role" {
   description = "Role for gitlabrunners"
 }
 
+output "gitlab_runner_workers_role" {
+  value       = "${aws_iam_role.runner.name}"
+  description = "Role for docker hosts spawned by gitlab runner"
+}
+
 output "gitlab_runner_security_group_id" {
   value       = "${aws_security_group.runner.id}"
   description = "Runner's security group ID"

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,9 +1,9 @@
-output "gitlab_runner_role" {
+output "gitlab_runner_role_name" {
   value       = "${aws_iam_role.instance.name}"
   description = "Role for gitlabrunners"
 }
 
-output "gitlab_runner_workers_role" {
+output "gitlab_runner_workers_role_name" {
   value       = "${aws_iam_role.runner.name}"
   description = "Role for docker hosts spawned by gitlab runner"
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,4 +1,4 @@
-output "gitlab_runner_role_name" {
+output "gitlab_runner_role" {
   value       = "${aws_iam_role.instance.name}"
   description = "Role for gitlabrunners"
 }

--- a/runner-from-userdata.tf
+++ b/runner-from-userdata.tf
@@ -59,7 +59,7 @@ data "template_file" "gitlab_runner" {
     runners_use_private_address = "${var.runners_use_private_address}"
     bucket_name                 = "${aws_s3_bucket.build_cache.bucket}"
     runner_environment_tag      = "${var.environment}"
-    instance-profile-name       = "${aws_iam_instance_profile.runner.name}"
+    instance_profile_name       = "${aws_iam_instance_profile.runner.name}"
     runners_config              = "${data.template_file.runners.rendered}"
   }
 }

--- a/runner-from-userdata.tf
+++ b/runner-from-userdata.tf
@@ -59,8 +59,8 @@ data "template_file" "gitlab_runner" {
     runners_use_private_address = "${var.runners_use_private_address}"
     bucket_name                 = "${aws_s3_bucket.build_cache.bucket}"
     runner_environment_tag      = "${var.environment}"
-
-    runners_config = "${data.template_file.runners.rendered}"
+    instance-profile-name       = "${aws_iam_instance_profile.runner.name}"
+    runners_config              = "${data.template_file.runners.rendered}"
   }
 }
 

--- a/template/gitlab-runner.tpl
+++ b/template/gitlab-runner.tpl
@@ -43,7 +43,7 @@ gitlab-runner register \
   --machine-machine-options "amazonec2-request-spot-instance=true" \
   --machine-machine-options "amazonec2-spot-price=${runners_spot_price_bid}" \
   --machine-machine-options "amazonec2-security-group=${runners_security_group_name}" \
-  --machine-machine-options "amazonec2-iam-instance-profile=${instance-profile-name}" \
+  --machine-machine-options "amazonec2-iam-instance-profile=${instance_profile_name}" \
   --machine-machine-options "amazonec2-tags=environment,${environment}" \
   --machine-machine-options "amazonec2-monitoring=${runners_monitoring}" \
   --machine-machine-options "amazonec2-root-size=${runners_root_size}" \

--- a/template/gitlab-runner.tpl
+++ b/template/gitlab-runner.tpl
@@ -43,6 +43,7 @@ gitlab-runner register \
   --machine-machine-options "amazonec2-request-spot-instance=true" \
   --machine-machine-options "amazonec2-spot-price=${runners_spot_price_bid}" \
   --machine-machine-options "amazonec2-security-group=${runners_security_group_name}" \
+  --machine-machine-options "amazonec2-iam-instance-profile=${instance-profile-name}" \
   --machine-machine-options "amazonec2-tags=environment,${environment}" \
   --machine-machine-options "amazonec2-monitoring=${runners_monitoring}" \
   --machine-machine-options "amazonec2-root-size=${runners_root_size}" \


### PR DESCRIPTION
Guys please have a look
Those changes will allow to create new empty blank role that will be assigned to docker hosts ec2 instances
This role is exported and users will be able to attach required policies to it  